### PR TITLE
Add cross-repo my-open-PRs GitHub view

### DIFF
--- a/lisp/eds-github.el
+++ b/lisp/eds-github.el
@@ -386,5 +386,119 @@ and \\`/ /' to clear all filters."
       (tabulated-list-print t))
     (pop-to-buffer buf)))
 
+;;; My pull requests (across all repositories)
+
+(defun eds-github/--fetch-my-prs (state)
+  "Fetch the authenticated user's pull requests filtered by STATE.
+STATE should be \"open\", \"closed\", or \"all\".  When STATE is
+\"all\", no state qualifier is passed to `gh search'.
+Returns a parsed JSON vector of PR objects."
+  (with-temp-buffer
+    (let* ((args (list "search" "prs"
+                       "--author" "@me"
+                       "--json" "number,title,state,repository,updatedAt,url"
+                       "--limit" (number-to-string eds-github/pr-limit)))
+           (args (if (and state (not (string= state "all")))
+                     (append args (list "--state" state))
+                   args))
+           (exit-code (apply #'process-file "gh" nil t nil args))
+           (output (string-trim (buffer-string))))
+      (unless (zerop exit-code)
+        (error "GitHub CLI search prs failed: %s" output))
+      (if (string-empty-p output)
+          (error "No output from gh CLI — is it installed and authenticated?")
+        (json-parse-string output :object-type 'alist)))))
+
+(defun eds-github/--format-my-pr-entry (pr)
+  "Format a single PR alist from `gh search prs' into a row.
+The row id is the PR URL so it can be opened across repositories."
+  (let* ((number (alist-get 'number pr))
+         (title (or (alist-get 'title pr) ""))
+         (state (upcase (or (alist-get 'state pr) "")))
+         (repo-obj (alist-get 'repository pr))
+         (repo (if (consp repo-obj)
+                   (or (alist-get 'nameWithOwner repo-obj) "")
+                 ""))
+         (updated (eds-github/--format-time (or (alist-get 'updatedAt pr) "")))
+         (url (or (alist-get 'url pr) ""))
+         (face (eds-github/--pr-state-face state)))
+    (list url
+          (vector repo
+                  (if number (number-to-string number) "")
+                  (propertize state 'face face)
+                  title
+                  updated))))
+
+(defun eds-github/--my-pr-header-line ()
+  "Build a header-line string showing the active my-PRs filter."
+  (format "My PRs [state: %s]"
+          (or eds-github/--pr-state eds-github/pr-default-state)))
+
+(defun eds-github/--refresh-my-prs ()
+  "Refresh the my-pull-requests list using the current state filter."
+  (let ((prs (eds-github/--fetch-my-prs
+              (or eds-github/--pr-state eds-github/pr-default-state))))
+    (setq tabulated-list-entries
+          (mapcar #'eds-github/--format-my-pr-entry
+                  (append prs nil)))
+    (setq header-line-format (eds-github/--my-pr-header-line))))
+
+(defun eds-github/my-pr-filter-state (state)
+  "Filter the my-pull-requests list by STATE and refresh.
+STATE should be \"open\", \"closed\", or \"all\"."
+  (interactive
+   (list (completing-read "PR state: " '("open" "closed" "all") nil t)))
+  (setq-local eds-github/--pr-state state)
+  (revert-buffer))
+
+(defun eds-github/my-pr-clear-filters ()
+  "Reset the my-pull-requests state filter to the default and refresh."
+  (interactive)
+  (setq-local eds-github/--pr-state eds-github/pr-default-state)
+  (revert-buffer))
+
+(defun eds-github/my-pr-view-at-point ()
+  "Open the pull request at point in the browser."
+  (interactive)
+  (let ((url (tabulated-list-get-id)))
+    (if (and url (not (string-empty-p url)))
+        (browse-url url)
+      (user-error "No PR at point"))))
+
+(defvar eds-github/my-prs-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") #'eds-github/my-pr-view-at-point)
+    (define-key map (kbd "/ s") #'eds-github/my-pr-filter-state)
+    (define-key map (kbd "/ /") #'eds-github/my-pr-clear-filters)
+    map)
+  "Keymap for `eds-github/my-prs-mode'.")
+
+(define-derived-mode eds-github/my-prs-mode tabulated-list-mode "GH-MyPRs"
+  "Major mode for listing the authenticated user's pull requests."
+  (setq tabulated-list-format
+        [("Repo" 30 t)
+         ("Num" 6 t)
+         ("State" 8 t)
+         ("Title" 50 t)
+         ("Updated" 16 t)])
+  (setq tabulated-list-padding 2)
+  (setq tabulated-list-sort-key '("Updated" . t))
+  (add-hook 'tabulated-list-revert-hook #'eds-github/--refresh-my-prs nil t)
+  (tabulated-list-init-header))
+
+;;;###autoload
+(defun eds-github/list-my-prs ()
+  "List the authenticated user's open GitHub pull requests across all repos.
+Uses `gh search prs --author @me'.  Use \\`/ s' to filter by state
+and \\`/ /' to reset the filter."
+  (interactive)
+  (let ((buf (get-buffer-create "*GitHub My PRs*")))
+    (with-current-buffer buf
+      (eds-github/my-prs-mode)
+      (setq-local eds-github/--pr-state eds-github/pr-default-state)
+      (eds-github/--refresh-my-prs)
+      (tabulated-list-print t))
+    (pop-to-buffer buf)))
+
 (provide 'eds-github)
 ;;; eds-github.el ends here

--- a/lisp/init-git.el
+++ b/lisp/init-git.el
@@ -75,5 +75,8 @@
 (autoload 'eds-github/list-prs "eds-github" nil t)
 (global-set-key (kbd "C-c G p") #'eds-github/list-prs)
 
+(autoload 'eds-github/list-my-prs "eds-github" nil t)
+(global-set-key (kbd "C-c G P") #'eds-github/list-my-prs)
+
 (provide 'init-git)
 ;;; init-git.el ends here

--- a/tests/test-eds-github.el
+++ b/tests/test-eds-github.el
@@ -392,7 +392,70 @@
           (eds-github/pr-clear-filters)
           (expect eds-github/--pr-state :to-equal "open")
           (expect eds-github/--pr-author :to-be nil)
-          (expect 'revert-buffer :to-have-been-called))))))
+          (expect 'revert-buffer :to-have-been-called)))))
+
+  (describe "eds-github/--fetch-my-prs"
+    (it "calls gh search with correct arguments for open PRs"
+      (spy-on 'process-file
+              :and-call-fake
+              (lambda (&rest _args)
+                (insert "[{\"number\":7,\"title\":\"Add search\",\"state\":\"open\",\"repository\":{\"nameWithOwner\":\"owner/repo\"},\"updatedAt\":\"2025-01-15T14:30:00Z\",\"url\":\"https://github.com/owner/repo/pull/7\"}]")
+                0))
+      (let* ((eds-github/pr-limit 25)
+             (prs (eds-github/--fetch-my-prs "open")))
+        (expect 'process-file :to-have-been-called-with
+                "gh" nil t nil
+                "search" "prs"
+                "--author" "@me"
+                "--json" "number,title,state,repository,updatedAt,url"
+                "--limit" "25"
+                "--state" "open")
+        (expect (length prs) :to-equal 1)
+        (expect (alist-get 'title (aref prs 0)) :to-equal "Add search")))
+
+    (it "omits --state when state is \"all\""
+      (spy-on 'process-file
+              :and-call-fake
+              (lambda (&rest _args)
+                (insert "[]")
+                0))
+      (let ((eds-github/pr-limit 10))
+        (eds-github/--fetch-my-prs "all")
+        (let ((args (spy-calls-args-for 'process-file 0)))
+          (expect (member "--state" args) :to-be nil))))
+
+    (it "signals an error when gh fails"
+      (spy-on 'process-file
+              :and-call-fake
+              (lambda (&rest _args)
+                (insert "not authenticated")
+                1))
+      (condition-case err
+          (eds-github/--fetch-my-prs "open")
+        (error
+         (expect (error-message-string err) :to-match "not authenticated")))))
+
+  (describe "eds-github/--format-my-pr-entry"
+    (it "produces a row with the repo, url id, and normalized state"
+      (let* ((pr '((number . 7)
+                   (title . "Add search")
+                   (state . "open")
+                   (repository . ((nameWithOwner . "owner/repo")))
+                   (updatedAt . "2025-01-15T14:30:00Z")
+                   (url . "https://github.com/owner/repo/pull/7")))
+             (entry (eds-github/--format-my-pr-entry pr)))
+        (expect (car entry) :to-equal "https://github.com/owner/repo/pull/7")
+        (expect (aref (cadr entry) 0) :to-equal "owner/repo")
+        (expect (aref (cadr entry) 1) :to-equal "7")
+        (expect (aref (cadr entry) 2) :to-equal "OPEN")
+        (expect (aref (cadr entry) 3) :to-equal "Add search")))
+
+    (it "handles a missing repository gracefully"
+      (let* ((pr '((number . 5)
+                   (repository . :null)
+                   (url . "https://github.com/x/y/pull/5")))
+             (entry (eds-github/--format-my-pr-entry pr)))
+        (expect (aref (cadr entry) 0) :to-equal "")))))
 
 (provide 'test-eds-github)
 ;;; test-eds-github.el ends here


### PR DESCRIPTION
List the authenticated user's open pull requests across all repositories using gh search prs --author @me, complementing the existing per-repo gh pr list view.

- eds-github/list-my-prs opens a *GitHub My PRs* tabulated buffer with Repo/Num/State/Title/Updated columns, state filtering (/ s, / /) and RET to open a PR via its URL (works across repos). - Normalize the lowercase state returned by gh search before the face lookup, and omit --state for the all filter. - Bind eds-github/list-my-prs to C-c G P in init-git.el. - Add buttercup tests for the fetcher args and row formatting.

Generated with ECA (https://eca.dev) (github-copilot/claude-opus-4.8)