### PR TITLE
Refactor GitHub tabulated list helpers

### DIFF
--- a/lisp/eds-github.el
+++ b/lisp/eds-github.el
@@ -30,11 +30,17 @@
 (require 'subr-x)
 (require 'tabulated-list)
 
+(defgroup eds-github nil
+  "GitHub integration for Emacs."
+  :group 'tools)
+
 (defvar eds-github/--current-repo nil
   "The repository currently displayed in the runs buffer.")
 
-(defvar eds-github/run-limit 20
-  "Maximum number of workflow runs to fetch.")
+(defcustom eds-github/run-limit 20
+  "Maximum number of workflow runs to fetch."
+  :type 'integer
+  :group 'eds-github)
 
 (defface eds-github/success-face
   '((t :inherit success :weight bold))
@@ -56,6 +62,54 @@
   "Face for cancelled workflow runs."
   :group 'eds-github)
 
+(defun eds-github/--gh-json (error-prefix &rest args)
+  "Run gh with ARGS and parse JSON output.
+ERROR-PREFIX is used when the gh CLI exits non-zero."
+  (with-temp-buffer
+    (let ((exit-code (apply #'process-file "gh" nil t nil args))
+          (output (string-trim (buffer-string))))
+      (unless (zerop exit-code)
+        (error "%s: %s" error-prefix output))
+      (if (string-empty-p output)
+          (error "No output from gh CLI — is it installed and authenticated?")
+        (json-parse-string output :object-type 'alist)))))
+
+(defun eds-github/--alist-string (key alist)
+  "Return string value for KEY in ALIST, or the empty string."
+  (or (alist-get key alist) ""))
+
+(defun eds-github/--nested-alist-string (object-key value-key alist)
+  "Return nested string VALUE-KEY from OBJECT-KEY in ALIST, or empty string."
+  (let ((object (alist-get object-key alist)))
+    (if (consp object)
+        (or (alist-get value-key object) "")
+      "")))
+
+(defun eds-github/--number-string (number)
+  "Return NUMBER as a string, or empty string when nil."
+  (if number (number-to-string number) ""))
+
+(defun eds-github/--set-tabulated-entries (items formatter)
+  "Set `tabulated-list-entries' from ITEMS using FORMATTER."
+  (setq tabulated-list-entries
+        (mapcar formatter (append items nil))))
+
+(defun eds-github/--setup-tabulated-list (format sort-key refresh-function)
+  "Set common tabulated-list variables.
+FORMAT is assigned to `tabulated-list-format', SORT-KEY is assigned
+to `tabulated-list-sort-key', and REFRESH-FUNCTION is added to the
+buffer-local `tabulated-list-revert-hook'."
+  (setq tabulated-list-format format)
+  (setq tabulated-list-padding 2)
+  (setq tabulated-list-sort-key sort-key)
+  (add-hook 'tabulated-list-revert-hook refresh-function nil t)
+  (tabulated-list-init-header))
+
+(defun eds-github/--id-at-point-or-error (message)
+  "Return `tabulated-list-get-id' or signal user error MESSAGE."
+  (or (tabulated-list-get-id)
+      (user-error "%s" message)))
+
 (defun eds-github/--status-face (status conclusion)
   "Return a face based on STATUS and CONCLUSION."
   (cond
@@ -76,83 +130,66 @@
 (defun eds-github/--fetch-runs (repo)
   "Fetch workflow runs for REPO using the gh CLI.
 Returns a parsed JSON vector of run objects."
-  (with-temp-buffer
-    (let ((exit-code (process-file "gh" nil t nil
-                                   "run" "list"
-                                   "--repo" repo
-                                   "--json" "databaseId,name,status,conclusion,headBranch,event,startedAt"
-                                   "--limit" (number-to-string eds-github/run-limit)))
-          (output (string-trim (buffer-string))))
-      (unless (zerop exit-code)
-        (error "GitHub CLI run list failed: %s" output))
-      (if (string-empty-p output)
-          (error "No output from gh CLI — is it installed and authenticated?")
-        (json-parse-string output :object-type 'alist)))))
+  (eds-github/--gh-json "GitHub CLI run list failed"
+                        "run" "list"
+                        "--repo" repo
+                        "--json" "databaseId,name,status,conclusion,headBranch,event,startedAt"
+                        "--limit" (number-to-string eds-github/run-limit)))
 
 (defun eds-github/--format-entry (run)
   "Format a single RUN alist into a `tabulated-list-entries' row."
   (let* ((id (alist-get 'databaseId run))
-         (name (or (alist-get 'name run) ""))
-         (status (or (alist-get 'status run) ""))
-         (conclusion (or (alist-get 'conclusion run) ""))
-         (branch (or (alist-get 'headBranch run) ""))
-         (event (or (alist-get 'event run) ""))
-         (started (eds-github/--format-time (or (alist-get 'startedAt run) "")))
+         (status (eds-github/--alist-string 'status run))
+         (conclusion (eds-github/--alist-string 'conclusion run))
          (display-status (if (string= status "completed") conclusion status))
          (face (eds-github/--status-face status conclusion)))
     (list id
           (vector (propertize display-status 'face face)
-                  name
-                  branch
-                  event
-                  started))))
+                  (eds-github/--alist-string 'name run)
+                  (eds-github/--alist-string 'headBranch run)
+                  (eds-github/--alist-string 'event run)
+                  (eds-github/--format-time
+                   (eds-github/--alist-string 'startedAt run))))))
 
 (defun eds-github/--refresh ()
   "Refresh the workflow runs list."
-  (let ((runs (eds-github/--fetch-runs eds-github/--current-repo)))
-    (setq tabulated-list-entries
-          (mapcar #'eds-github/--format-entry
-                  (append runs nil)))))
+  (eds-github/--set-tabulated-entries
+   (eds-github/--fetch-runs eds-github/--current-repo)
+   #'eds-github/--format-entry))
 
 (defun eds-github/view-run-at-point ()
   "Open the workflow run at point in the browser."
   (interactive)
-  (let ((id (tabulated-list-get-id)))
-    (if id
-        (shell-command
-         (format "gh run view %d --repo %s --web"
-                 id
-                 (shell-quote-argument eds-github/--current-repo)))
-      (user-error "No run at point"))))
+  (let ((id (eds-github/--id-at-point-or-error "No run at point")))
+    (shell-command
+     (format "gh run view %d --repo %s --web"
+             id
+             (shell-quote-argument eds-github/--current-repo)))))
 
 (defun eds-github/rerun-at-point ()
   "Rerun the workflow run at point."
   (interactive)
-  (let ((id (tabulated-list-get-id)))
-    (if id
-        (when (yes-or-no-p (format "Rerun workflow %d?" id))
-          (shell-command
-           (format "gh run rerun %d --repo %s"
-                   id
-                   (shell-quote-argument eds-github/--current-repo)))
-          (revert-buffer))
-      (user-error "No run at point"))))
+  (let ((id (eds-github/--id-at-point-or-error "No run at point")))
+    (when (yes-or-no-p (format "Rerun workflow %d?" id))
+      (shell-command
+       (format "gh run rerun %d --repo %s"
+               id
+               (shell-quote-argument eds-github/--current-repo)))
+      (revert-buffer))))
 
 (defun eds-github/cancel-at-point (force)
   "Cancel the workflow run at point.
 With prefix argument FORCE, pass --force to cancel even if completed."
   (interactive "P")
-  (let ((id (tabulated-list-get-id)))
-    (if id
-        (when (yes-or-no-p (format "Cancel workflow %d%s?"
-                                   id (if force " (force)" "")))
-          (shell-command
-           (format "gh run cancel %d --repo %s%s"
-                   id
-                   (shell-quote-argument eds-github/--current-repo)
-                   (if force " --force" "")))
-          (revert-buffer))
-      (user-error "No run at point"))))
+  (let ((id (eds-github/--id-at-point-or-error "No run at point")))
+    (when (yes-or-no-p (format "Cancel workflow %d%s?"
+                               id (if force " (force)" "")))
+      (shell-command
+       (format "gh run cancel %d --repo %s%s"
+               id
+               (shell-quote-argument eds-github/--current-repo)
+               (if force " --force" "")))
+      (revert-buffer))))
 
 (defvar eds-github/runs-mode-map
   (let ((map (make-sparse-keymap)))
@@ -164,16 +201,14 @@ With prefix argument FORCE, pass --force to cancel even if completed."
 
 (define-derived-mode eds-github/runs-mode tabulated-list-mode "GH-Runs"
   "Major mode for listing GitHub Actions workflow runs."
-  (setq tabulated-list-format
-        [("Status" 12 t)
-         ("Name" 35 t)
-         ("Branch" 25 t)
-         ("Event" 12 t)
-         ("Started" 16 t)])
-  (setq tabulated-list-padding 2)
-  (setq tabulated-list-sort-key '("Started" . t))
-  (add-hook 'tabulated-list-revert-hook #'eds-github/--refresh nil t)
-  (tabulated-list-init-header))
+  (eds-github/--setup-tabulated-list
+   [("Status" 12 t)
+    ("Name" 35 t)
+    ("Branch" 25 t)
+    ("Event" 12 t)
+    ("Started" 16 t)]
+   '("Started" . t)
+   #'eds-github/--refresh))
 
 (defun eds-github/--default-repo ()
   "Attempt to determine the repo from the current git remote."
@@ -204,11 +239,17 @@ Defaults to the current repository's GitHub remote if available."
 ;;; Pull Requests
 ;;; -----------------------------------------------------------------
 
-(defvar eds-github/pr-limit 30
-  "Maximum number of pull requests to fetch.")
+(defcustom eds-github/pr-limit 30
+  "Maximum number of pull requests to fetch."
+  :type 'integer
+  :group 'eds-github)
 
-(defvar eds-github/pr-default-state "open"
-  "Default state filter for pull requests (\"open\", \"closed\", or \"all\").")
+(defcustom eds-github/pr-default-state "open"
+  "Default state filter for pull requests."
+  :type '(choice (const :tag "Open" "open")
+                 (const :tag "Closed" "closed")
+                 (const :tag "All" "all"))
+  :group 'eds-github)
 
 (defvar-local eds-github/--pr-repo nil
   "The repository currently displayed in the PRs buffer.")
@@ -218,6 +259,19 @@ Defaults to the current repository's GitHub remote if available."
 
 (defvar-local eds-github/--pr-author nil
   "Current author filter for the PRs buffer (nil means all).")
+
+(defun eds-github/--read-pr-state ()
+  "Read a pull request state filter from the minibuffer."
+  (completing-read "PR state: " '("open" "closed" "all") nil t))
+
+(defun eds-github/--set-pr-state (state)
+  "Set the current PR STATE filter and refresh the buffer."
+  (setq-local eds-github/--pr-state state)
+  (revert-buffer))
+
+(defun eds-github/--reset-pr-state ()
+  "Reset the current PR state filter to `eds-github/pr-default-state'."
+  (setq-local eds-github/--pr-state eds-github/pr-default-state))
 
 (defface eds-github/pr-open-face
   '((t :inherit success :weight bold))
@@ -242,46 +296,40 @@ Defaults to the current repository's GitHub remote if available."
    ((string= state "MERGED") 'eds-github/pr-merged-face)
    (t 'default)))
 
+(defun eds-github/--propertized-pr-state (state &optional upcase)
+  "Return STATE propertized with its PR state face.
+When UPCASE is non-nil, uppercase STATE before choosing the face."
+  (let ((state (if upcase
+                   (upcase (or state ""))
+                 (or state ""))))
+    (propertize state 'face (eds-github/--pr-state-face state))))
+
 (defun eds-github/--fetch-prs (repo state &optional author)
   "Fetch pull requests for REPO filtered by STATE and optionally AUTHOR.
 STATE should be \"open\", \"closed\", or \"all\".
 Returns a parsed JSON vector of PR objects."
-  (with-temp-buffer
-    (let* ((args (list "pr" "list"
-                       "--repo" repo
-                       "--json" "number,title,state,author,headRefName,createdAt,updatedAt"
-                       "--state" state
-                       "--limit" (number-to-string eds-github/pr-limit)))
-           (args (if (and author (not (string-empty-p author)))
-                     (append args (list "--author" author))
-                   args))
-           (exit-code (apply #'process-file "gh" nil t nil args))
-           (output (string-trim (buffer-string))))
-      (unless (zerop exit-code)
-        (error "GitHub CLI pr list failed: %s" output))
-      (if (string-empty-p output)
-          (error "No output from gh CLI — is it installed and authenticated?")
-        (json-parse-string output :object-type 'alist)))))
+  (let* ((args (list "pr" "list"
+                     "--repo" repo
+                     "--json" "number,title,state,author,headRefName,createdAt,updatedAt"
+                     "--state" state
+                     "--limit" (number-to-string eds-github/pr-limit)))
+         (args (if (and author (not (string-empty-p author)))
+                   (append args (list "--author" author))
+                 args)))
+    (apply #'eds-github/--gh-json "GitHub CLI pr list failed" args)))
 
 (defun eds-github/--format-pr-entry (pr)
   "Format a single PR alist into a `tabulated-list-entries' row."
-  (let* ((number (alist-get 'number pr))
-         (title (or (alist-get 'title pr) ""))
-         (state (or (alist-get 'state pr) ""))
-         (author-obj (alist-get 'author pr))
-         (author (if (consp author-obj)
-                     (or (alist-get 'login author-obj) "")
-                   ""))
-         (branch (or (alist-get 'headRefName pr) ""))
-         (updated (eds-github/--format-time (or (alist-get 'updatedAt pr) "")))
-         (face (eds-github/--pr-state-face state)))
+  (let ((number (alist-get 'number pr))
+        (state (eds-github/--alist-string 'state pr)))
     (list number
           (vector (number-to-string number)
-                  (propertize state 'face face)
-                  title
-                  author
-                  branch
-                  updated))))
+                  (eds-github/--propertized-pr-state state)
+                  (eds-github/--alist-string 'title pr)
+                  (eds-github/--nested-alist-string 'author 'login pr)
+                  (eds-github/--alist-string 'headRefName pr)
+                  (eds-github/--format-time
+                   (eds-github/--alist-string 'updatedAt pr))))))
 
 (defun eds-github/--pr-header-line ()
   "Build a header-line string showing active PR filters."
@@ -298,22 +346,19 @@ Returns a parsed JSON vector of PR objects."
 
 (defun eds-github/--refresh-prs ()
   "Refresh the pull requests list using current filters."
-  (let ((prs (eds-github/--fetch-prs eds-github/--pr-repo
-                                      (or eds-github/--pr-state
-                                          eds-github/pr-default-state)
-                                      eds-github/--pr-author)))
-    (setq tabulated-list-entries
-          (mapcar #'eds-github/--format-pr-entry
-                  (append prs nil)))
-    (setq header-line-format (eds-github/--pr-header-line))))
+  (eds-github/--set-tabulated-entries
+   (eds-github/--fetch-prs eds-github/--pr-repo
+                           (or eds-github/--pr-state
+                               eds-github/pr-default-state)
+                           eds-github/--pr-author)
+   #'eds-github/--format-pr-entry)
+  (setq header-line-format (eds-github/--pr-header-line)))
 
 (defun eds-github/pr-filter-state (state)
   "Filter pull requests by STATE and refresh the list.
 STATE should be \"open\", \"closed\", or \"all\"."
-  (interactive
-   (list (completing-read "PR state: " '("open" "closed" "all") nil t)))
-  (setq-local eds-github/--pr-state state)
-  (revert-buffer))
+  (interactive (list (eds-github/--read-pr-state)))
+  (eds-github/--set-pr-state state))
 
 (defun eds-github/pr-filter-author (author)
   "Filter pull requests by AUTHOR and refresh the list.
@@ -326,20 +371,18 @@ If AUTHOR is empty, clear the author filter."
 (defun eds-github/pr-clear-filters ()
   "Clear all PR filters and refresh the list."
   (interactive)
-  (setq-local eds-github/--pr-state eds-github/pr-default-state)
+  (eds-github/--reset-pr-state)
   (setq-local eds-github/--pr-author nil)
   (revert-buffer))
 
 (defun eds-github/pr-view-at-point ()
   "Open the pull request at point in the browser."
   (interactive)
-  (let ((number (tabulated-list-get-id)))
-    (if number
-        (shell-command
-         (format "gh pr view %d --repo %s --web"
-                 number
-                 (shell-quote-argument eds-github/--pr-repo)))
-      (user-error "No PR at point"))))
+  (let ((number (eds-github/--id-at-point-or-error "No PR at point")))
+    (shell-command
+     (format "gh pr view %d --repo %s --web"
+             number
+             (shell-quote-argument eds-github/--pr-repo)))))
 
 (defvar eds-github/prs-mode-map
   (let ((map (make-sparse-keymap)))
@@ -352,17 +395,15 @@ If AUTHOR is empty, clear the author filter."
 
 (define-derived-mode eds-github/prs-mode tabulated-list-mode "GH-PRs"
   "Major mode for listing GitHub pull requests."
-  (setq tabulated-list-format
-        [("Num" 6 t)
-         ("State" 8 t)
-         ("Title" 45 t)
-         ("Author" 16 t)
-         ("Branch" 25 t)
-         ("Updated" 16 t)])
-  (setq tabulated-list-padding 2)
-  (setq tabulated-list-sort-key '("Updated" . t))
-  (add-hook 'tabulated-list-revert-hook #'eds-github/--refresh-prs nil t)
-  (tabulated-list-init-header))
+  (eds-github/--setup-tabulated-list
+   [("Num" 6 t)
+    ("State" 8 t)
+    ("Title" 45 t)
+    ("Author" 16 t)
+    ("Branch" 25 t)
+    ("Updated" 16 t)]
+   '("Updated" . t)
+   #'eds-github/--refresh-prs))
 
 ;;;###autoload
 (defun eds-github/list-prs (repo)
@@ -393,41 +434,26 @@ and \\`/ /' to clear all filters."
 STATE should be \"open\", \"closed\", or \"all\".  When STATE is
 \"all\", no state qualifier is passed to `gh search'.
 Returns a parsed JSON vector of PR objects."
-  (with-temp-buffer
-    (let* ((args (list "search" "prs"
-                       "--author" "@me"
-                       "--json" "number,title,state,repository,updatedAt,url"
-                       "--limit" (number-to-string eds-github/pr-limit)))
-           (args (if (and state (not (string= state "all")))
-                     (append args (list "--state" state))
-                   args))
-           (exit-code (apply #'process-file "gh" nil t nil args))
-           (output (string-trim (buffer-string))))
-      (unless (zerop exit-code)
-        (error "GitHub CLI search prs failed: %s" output))
-      (if (string-empty-p output)
-          (error "No output from gh CLI — is it installed and authenticated?")
-        (json-parse-string output :object-type 'alist)))))
+  (let* ((args (list "search" "prs"
+                     "--author" "@me"
+                     "--json" "number,title,state,repository,updatedAt,url"
+                     "--limit" (number-to-string eds-github/pr-limit)))
+         (args (if (and state (not (string= state "all")))
+                   (append args (list "--state" state))
+                 args)))
+    (apply #'eds-github/--gh-json "GitHub CLI search prs failed" args)))
 
 (defun eds-github/--format-my-pr-entry (pr)
   "Format a single PR alist from `gh search prs' into a row.
 The row id is the PR URL so it can be opened across repositories."
-  (let* ((number (alist-get 'number pr))
-         (title (or (alist-get 'title pr) ""))
-         (state (upcase (or (alist-get 'state pr) "")))
-         (repo-obj (alist-get 'repository pr))
-         (repo (if (consp repo-obj)
-                   (or (alist-get 'nameWithOwner repo-obj) "")
-                 ""))
-         (updated (eds-github/--format-time (or (alist-get 'updatedAt pr) "")))
-         (url (or (alist-get 'url pr) ""))
-         (face (eds-github/--pr-state-face state)))
-    (list url
-          (vector repo
-                  (if number (number-to-string number) "")
-                  (propertize state 'face face)
-                  title
-                  updated))))
+  (let ((state (eds-github/--alist-string 'state pr)))
+    (list (eds-github/--alist-string 'url pr)
+          (vector (eds-github/--nested-alist-string 'repository 'nameWithOwner pr)
+                  (eds-github/--number-string (alist-get 'number pr))
+                  (eds-github/--propertized-pr-state state t)
+                  (eds-github/--alist-string 'title pr)
+                  (eds-github/--format-time
+                   (eds-github/--alist-string 'updatedAt pr))))))
 
 (defun eds-github/--my-pr-header-line ()
   "Build a header-line string showing the active my-PRs filter."
@@ -436,32 +462,29 @@ The row id is the PR URL so it can be opened across repositories."
 
 (defun eds-github/--refresh-my-prs ()
   "Refresh the my-pull-requests list using the current state filter."
-  (let ((prs (eds-github/--fetch-my-prs
-              (or eds-github/--pr-state eds-github/pr-default-state))))
-    (setq tabulated-list-entries
-          (mapcar #'eds-github/--format-my-pr-entry
-                  (append prs nil)))
-    (setq header-line-format (eds-github/--my-pr-header-line))))
+  (eds-github/--set-tabulated-entries
+   (eds-github/--fetch-my-prs
+    (or eds-github/--pr-state eds-github/pr-default-state))
+   #'eds-github/--format-my-pr-entry)
+  (setq header-line-format (eds-github/--my-pr-header-line)))
 
 (defun eds-github/my-pr-filter-state (state)
   "Filter the my-pull-requests list by STATE and refresh.
 STATE should be \"open\", \"closed\", or \"all\"."
-  (interactive
-   (list (completing-read "PR state: " '("open" "closed" "all") nil t)))
-  (setq-local eds-github/--pr-state state)
-  (revert-buffer))
+  (interactive (list (eds-github/--read-pr-state)))
+  (eds-github/--set-pr-state state))
 
 (defun eds-github/my-pr-clear-filters ()
   "Reset the my-pull-requests state filter to the default and refresh."
   (interactive)
-  (setq-local eds-github/--pr-state eds-github/pr-default-state)
+  (eds-github/--reset-pr-state)
   (revert-buffer))
 
 (defun eds-github/my-pr-view-at-point ()
   "Open the pull request at point in the browser."
   (interactive)
-  (let ((url (tabulated-list-get-id)))
-    (if (and url (not (string-empty-p url)))
+  (let ((url (eds-github/--id-at-point-or-error "No PR at point")))
+    (if (not (string-empty-p url))
         (browse-url url)
       (user-error "No PR at point"))))
 
@@ -475,16 +498,14 @@ STATE should be \"open\", \"closed\", or \"all\"."
 
 (define-derived-mode eds-github/my-prs-mode tabulated-list-mode "GH-MyPRs"
   "Major mode for listing the authenticated user's pull requests."
-  (setq tabulated-list-format
-        [("Repo" 30 t)
-         ("Num" 6 t)
-         ("State" 8 t)
-         ("Title" 50 t)
-         ("Updated" 16 t)])
-  (setq tabulated-list-padding 2)
-  (setq tabulated-list-sort-key '("Updated" . t))
-  (add-hook 'tabulated-list-revert-hook #'eds-github/--refresh-my-prs nil t)
-  (tabulated-list-init-header))
+  (eds-github/--setup-tabulated-list
+   [("Repo" 30 t)
+    ("Num" 6 t)
+    ("State" 8 t)
+    ("Title" 50 t)
+    ("Updated" 16 t)]
+   '("Updated" . t)
+   #'eds-github/--refresh-my-prs))
 
 ;;;###autoload
 (defun eds-github/list-my-prs ()

--- a/lisp/eds-github.el
+++ b/lisp/eds-github.el
@@ -85,7 +85,7 @@ ERROR-PREFIX is used when the gh CLI exits non-zero."
   "Return nested string VALUE-KEY from OBJECT-KEY in ALIST, or empty string."
   (let ((object (alist-get object-key alist)))
     (if (consp object)
-        (or (alist-get value-key object) "")
+        (eds-github/--alist-string value-key object)
       "")))
 
 (defun eds-github/--number-string (number)

--- a/lisp/eds-github.el
+++ b/lisp/eds-github.el
@@ -76,7 +76,10 @@ ERROR-PREFIX is used when the gh CLI exits non-zero."
 
 (defun eds-github/--alist-string (key alist)
   "Return string value for KEY in ALIST, or the empty string."
-  (or (alist-get key alist) ""))
+  (let ((value (alist-get key alist)))
+    (if (and value (not (eq value json-null)) (stringp value))
+        value
+      "")))
 
 (defun eds-github/--nested-alist-string (object-key value-key alist)
   "Return nested string VALUE-KEY from OBJECT-KEY in ALIST, or empty string."


### PR DESCRIPTION
## Summary
- Extract shared helpers for GitHub CLI JSON parsing, tabulated-list setup, state filters, and row formatting.
- Add an `eds-github` customization group and convert existing limits/default state to `defcustom`.
- Preserve existing public commands, keymaps, shell command strings, table columns, and behavior.

## Verification
- `/Users/sullie09/git/emacs.d/run-tests.sh eds-github`
- `/Users/sullie09/git/emacs.d/run-tests.sh`
- Pre-push hook ran full test suite successfully.

🤖 Generated with [ECA](https://eca.dev) (github-copilot/gpt-5.5)